### PR TITLE
Add back clipping and fix point issue

### DIFF
--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -297,10 +297,20 @@ module.exports = function(Chart) {
 				meta.dataset.transition(easingDecimal).draw();
 			}
 
+			// Restore from the clipping operation started in Chart.Controller
+			var context = me.chart.chart.ctx;
+			context.restore();
+
 			// Draw the points
 			for (i=0, ilen=points.length; i<ilen; ++i) {
 				points[i].draw();
 			}
+
+			// Resume the clipping operation started in Chart.Controller
+			context.save();
+			context.beginPath();
+			context.rect(me.chart.chartArea.left, me.chart.chartArea.top, me.chart.chartArea.right - me.chart.chartArea.left, me.chart.chartArea.bottom - me.chart.chartArea.top);
+			context.clip();
 		},
 
 		setHoverStyle: function(point) {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -554,6 +554,13 @@ module.exports = function(Chart) {
 				me.scale.draw();
 			}
 
+			// Clip out the chart area so that anything outside does not draw. This is necessary for zoom and pan to function
+			var context = this.chart.ctx;
+			context.save();
+			context.beginPath();
+			context.rect(this.chartArea.left, this.chartArea.top, this.chartArea.right - this.chartArea.left, this.chartArea.bottom - this.chartArea.top);
+			context.clip();
+
 			Chart.plugins.notify('beforeDatasetsDraw', [me, easingDecimal]);
 
 			// Draw each dataset via its respective controller (reversed to support proper line stacking)
@@ -562,6 +569,9 @@ module.exports = function(Chart) {
 					me.getDatasetMeta(datasetIndex).controller.draw(ease);
 				}
 			}, me, true);
+
+			// Restore from the clipping operation
+			context.restore();
 
 			Chart.plugins.notify('afterDatasetsDraw', [me, easingDecimal]);
 


### PR DESCRIPTION
Add back clipping removed in #2278.  Prevent line points from being clipped by turning off clipping while drawing line points.

Comparison Pens: [before](http://codepen.io/anon/pen/JRmapN) and [after](http://codepen.io/anon/pen/BLqOJG)
